### PR TITLE
Add .jekyllignore to skip Astro sources for Pages

### DIFF
--- a/.jekyllignore
+++ b/.jekyllignore
@@ -1,0 +1,2 @@
+# Ignore Astro docs sources so GitHub Pages' Jekyll runner skips them
+packages/docs/


### PR DESCRIPTION
Pages’ managed Jekyll pass was reading `packages/docs/src/components/Sidebar.astro` and
  treating the leading `---` as YAML front matter, then crashing on the `import`.

This adds `.jekyllignore` to exclude the Astro source tree so Jekyll only processes the already-built static output from `withastro/action`.