### PR TITLE
fix: correct Widget Studio URL in widget-actions guide

### DIFF
--- a/packages/docs/src/content/docs/guides/widget-actions.mdx
+++ b/packages/docs/src/content/docs/guides/widget-actions.mdx
@@ -37,5 +37,5 @@ Looking for a full server example? The [ChatKit Python SDK docs](https://openai.
 
 ## Design widgets quickly
 
-Use the [Widget Studio](https://chatkit.studio/widgets) to experiment with card layouts, list rows, and preview components. When you are satisfied, copy the generated JSON into your integration and serve it from your backend.
+Use the [Widget Studio](https://widgets.chatkit.studio/) to experiment with card layouts, list rows, and preview components. When you are satisfied, copy the generated JSON into your integration and serve it from your backend.
 


### PR DESCRIPTION
Change Widget Studio link from https://chatkit.studio/widgets to https://widgets.chatkit.studio/ as the /widgets path leads to a blank page