### PR TITLE
docs(types): fix broken ChatKit docs link to chatkit-js

### DIFF
--- a/packages/chatkit/types/index.d.ts
+++ b/packages/chatkit/types/index.d.ts
@@ -164,7 +164,7 @@ export type StartScreenOption = {
 export type WidgetsOption = {
   /**
    * Called when a widget action is triggered.
-   * See https://openai.github.io/chatkit/guides/widget-actions/ for details.
+   * See https://openai.github.io/chatkit-js/guides/widget-actions/ for details.
    */
   onAction?: (
     action: { type: string; payload?: Record<string, unknown> },
@@ -791,7 +791,7 @@ export interface OpenAIChatKit extends HTMLElement {
 
   /**
    * Sends a custom application-defined action to your backend.
-   * See https://openai.github.io/chatkit/guides/widget-actions/ for more details.
+   * See https://openai.github.io/chatkit-js/guides/widget-actions/ for more details.
    */
   sendCustomAction(
     action: { type: string; payload?: Record<string, unknown> },


### PR DESCRIPTION

Apologies for the confusion. The previous pull request #16 referenced the wrong branch.
This PR reopens the same change from the correct branch.

---

The documentation links in index.d.ts currently point to
https://openai.github.io/chatkit/ which not exists and leads to 404 errors. ⚠️

This PR updates all references to use the correct base URL:
https://openai.github.io/chatkit-js/

No runtime or type changes — only comment/documentation updates. Thank you! 👍
