### PR TITLE
fix(docs): update authentication docs to fix broken custom backend URL

### DIFF
--- a/packages/docs/src/content/docs/guides/authentication.mdx
+++ b/packages/docs/src/content/docs/guides/authentication.mdx
@@ -7,7 +7,7 @@ import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 :::note[Note]
 This guide is for **hosted** integrations.
-If you are using `ChatKit.js` with a custom backend, see [Custom Backends](/guides/custom-backends).
+If you are using `ChatKit.js` with a custom backend, see [Custom Backends](/chatkit-js/guides/custom-backends).
 :::
 
 ChatKit uses short‑lived client tokens issued by your server. Your backend creates a session and returns a token to trusted clients. Clients never use your API key directly.


### PR DESCRIPTION
Link to `Custom Backends` on `Authentication` page is broken.

This PR fixes the issue where relative links inside .mdx content is not working as expected because the `base` configuration defined in https://github.com/openai/chatkit-js/blob/main/packages/docs/astro.config.ts#L73 does not effect to links inside .mdx content.