### PR TITLE
chore: adjust to create tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Changeset
         uses: changesets/action@v1
         with:
-          publish: pnpm ci:publish
+          version: pnpm changeset version
+          publish: pnpm changeset publish
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "format": "prettier --write .",
     "types": "pnpm -r run types",
     "clean": "pnpm -r run clean",
-    "check": "prettier --check . && pnpm -r run lint && pnpm types && pnpm -r run test",
-    "ci:publish": "pnpm publish -r --access public",
-    "release": "changeset version && pnpm -r build && changeset publish"
+    "check": "prettier --check . && pnpm -r run lint && pnpm types && pnpm -r run test"
   },
   "devDependencies": {
     "@changesets/cli": "2.27.10",


### PR DESCRIPTION
- Use `changeset` to publish so we create tags properly
- Automatically create github releases on when we cut a version