### PR TITLE
[bug] Fix type for Checkbox defaultChecked

### DIFF
--- a/.changeset/bright-apricots-learn.md
+++ b/.changeset/bright-apricots-learn.md
@@ -1,0 +1,5 @@
+---
+'@openai/chatkit': patch
+---
+
+Fix type for Checkbox `defaultChecked`

--- a/packages/chatkit/types/widgets.d.ts
+++ b/packages/chatkit/types/widgets.d.ts
@@ -333,7 +333,7 @@ export type Checkbox = {
   id?: string;
   name: string;
   label?: string;
-  defaultChecked?: string;
+  defaultChecked?: boolean;
   onChangeAction?: ActionConfig;
   disabled?: boolean;
   required?: boolean;


### PR DESCRIPTION
The type for the `Checkbox` property `defaultChecked` should be `boolean`, not `string`.

This is a type-only, backwards-compatible change. ChatKit will continue to accept `string`s for this property from existing SDK versions.