### PR TITLE
Pass signal to addEventListener when registering event handlers

### DIFF
--- a/packages/chatkit-react/src/ChatKit.tsx
+++ b/packages/chatkit-react/src/ChatKit.tsx
@@ -63,13 +63,17 @@ export const ChatKit = React.forwardRef<OpenAIChatKit, ChatKitProps>(
 
       const controller = new AbortController();
       for (const eventName of EVENT_NAMES) {
-        el.addEventListener(eventName, (e) => {
-          const handlerName = EVENT_HANDLER_MAP[eventName];
-          const handler = control.handlers[handlerName];
-          if (typeof handler === 'function') {
-            handler(e.detail as any);
-          }
-        });
+        el.addEventListener(
+          eventName,
+          (e) => {
+            const handlerName = EVENT_HANDLER_MAP[eventName];
+            const handler = control.handlers[handlerName];
+            if (typeof handler === 'function') {
+              handler(e.detail as any);
+            }
+          },
+          { signal: controller.signal },
+        );
       }
       return () => {
         controller.abort();


### PR DESCRIPTION
This was accidentally left out in a previous fix.