### PR TITLE
Add `chatkit.tool.change` event

### DIFF
--- a/packages/chatkit-react/src/ChatKit.tsx
+++ b/packages/chatkit-react/src/ChatKit.tsx
@@ -27,6 +27,7 @@ const EVENT_HANDLER_MAP: {
   'chatkit.thread.change': 'onThreadChange',
   'chatkit.thread.load.start': 'onThreadLoadStart',
   'chatkit.thread.load.end': 'onThreadLoadEnd',
+  'chatkit.tool.change': 'onToolChange',
   'chatkit.ready': 'onReady',
   'chatkit.effect': 'onEffect',
 };

--- a/packages/chatkit/types/index.d.ts
+++ b/packages/chatkit/types/index.d.ts
@@ -1019,6 +1019,9 @@ export type ChatKitEvents = {
   /** Emitted when ChatKit finished loading a thread. */
   'chatkit.thread.load.end': CustomEvent<{ threadId: string }>;
 
+  /** Emitted when the selected composer tool changes. */
+  'chatkit.tool.change': CustomEvent<{ toolId: string | null }>;
+
   /** Diagnostic events that can be used for logging/analytics. */
   'chatkit.log': CustomEvent<{
     name: string;


### PR DESCRIPTION
Emitted when the user selects a different tool from the composer tool menu / unselects the currently selected tool.

Can be used, for instance, to display different start screen prompts depending on which tool is selected.
