### PR TITLE
Add lucide: icon name type; add frameTitle option

### DIFF
--- a/packages/chatkit/types/index.d.ts
+++ b/packages/chatkit/types/index.d.ts
@@ -37,7 +37,7 @@ export type ChatKitOptions = {
    * Accessible title for the ChatKit iframe element.
    * @default "Chat"
    */
-  frameTitle?: string
+  frameTitle?: string;
 
   /**
    * The ID of the thread to show when ChatKit is mounted or opened for the first time.


### PR DESCRIPTION
frameTitle | ChatKitIcon | LucideIcon
--- | --- | ---
<img width="900" height="446" alt="Screenshot 2026-01-09 at 10 14 00 AM" src="https://github.com/user-attachments/assets/9b0e53d7-7a3c-41ac-9958-66fd6055bd5f" /> | <img width="1426" height="779" alt="Screenshot 2026-01-09 at 10 15 01 AM" src="https://github.com/user-attachments/assets/72632d52-62e1-4409-8e79-c9d3ffb9c39a" /> |  <img width="1388" height="371" alt="Screenshot 2026-01-09 at 10 15 09 AM" src="https://github.com/user-attachments/assets/7c23f40c-3b81-401c-acb1-488da7dc5310" />



