### PR TITLE
Add ChatKitOptions.entities.showComposerMenu option

### DIFF
--- a/packages/chatkit/types/index.d.ts
+++ b/packages/chatkit/types/index.d.ts
@@ -202,6 +202,16 @@ export type EntitiesOption = {
    * Powers tag autocomplete within the composer.
    */
   onTagSearch?: (query: string) => Promise<Entity[]>;
+
+  /**
+   * Whether to render a composer button that inserts "@" into
+   * the textarea and triggers a tag search on click.
+   * Only renders when {@link EntitiesOption.onTagSearch} is provided.
+   *
+   * @default false
+   */
+  showComposerMenu?: boolean;
+
   /** Called when a rendered entity is clicked. */
   onClick?: (entity: Entity) => void;
   /**


### PR DESCRIPTION
When true, will show a button in the composer that inserts "@" into the textarea and triggers entity tag search:

<img width="300" alt="Screenshot 2026-01-15 at 8 26 21 PM" src="https://github.com/user-attachments/assets/de1f53c0-9f98-43bf-a0aa-9dc40c911b83" />

(Just an example, placement depends on composer variation)
