### PR TITLE
Add `chatkit.deeplink` event and `onDeeplink` prop

### DIFF
--- a/packages/chatkit-react/src/ChatKit.tsx
+++ b/packages/chatkit-react/src/ChatKit.tsx
@@ -30,6 +30,7 @@ const EVENT_HANDLER_MAP: {
   'chatkit.tool.change': 'onToolChange',
   'chatkit.ready': 'onReady',
   'chatkit.effect': 'onEffect',
+  'chatkit.deeplink': 'onDeeplink',
 };
 
 const EVENT_NAMES = Object.keys(EVENT_HANDLER_MAP) as (keyof ChatKitEvents)[];

--- a/packages/chatkit/types/index.d.ts
+++ b/packages/chatkit/types/index.d.ts
@@ -1114,6 +1114,12 @@ export type ChatKitEvents = {
     data?: Record<string, unknown>;
   }>;
 
+  /** Emitted when a chatkit-link:// deeplink is clicked. */
+  'chatkit.deeplink': CustomEvent<{
+    name: string;
+    data?: Record<string, unknown>;
+  }>;
+
   /** Emitted when the assistant begins sending a response. */
   'chatkit.response.start': CustomEvent<void>;
 

--- a/packages/docs/src/content/docs/quick-reference/use-chatkit.mdx
+++ b/packages/docs/src/content/docs/quick-reference/use-chatkit.mdx
@@ -29,6 +29,7 @@ type UseChatKitOptions = ChatKitOptions &
     onError: (event: { error: Error }) => void;
     onLog: (event: { name: string; data?: Record<string, unknown> }) => void;
     onEffect: (event: { name: string; data?: Record<string, unknown> }) => void;
+    onDeeplink: (event: { name: string; data?: Record<string, unknown> }) => void;
   }>;
 ```
 


### PR DESCRIPTION
This allows custom markdown links with `chatkit-link://` schemes in assistant messages to be handled by listening to the `chatkit.deeplink` event (vanilla js) or providing an `onDeeplink` handler (react).