### PR TITLE
Add types for Table, Table.Row, and Table.Cell widget components

### DIFF
--- a/.changeset/light-frogs-cry.md
+++ b/.changeset/light-frogs-cry.md
@@ -1,0 +1,5 @@
+---
+'@openai/chatkit': minor
+---
+
+Added types for Table, Table.Row, and Table.Cell widget components

--- a/packages/chatkit/types/widgets.d.ts
+++ b/packages/chatkit/types/widgets.d.ts
@@ -21,6 +21,9 @@ export type WidgetComponent =
   | Input
   | Label
   | RadioGroup
+  | Table
+  | TableRow
+  | TableCell
   | Textarea
   | Transition;
 
@@ -245,6 +248,35 @@ export type Button = {
   uniform?: boolean;
   block?: boolean;
   disabled?: boolean;
+};
+
+type Table = {
+  type: 'Table';
+  key?: string;
+  id?: string;
+  children?: TableRow[];
+};
+
+type TableRow = {
+  type: 'Table.Row';
+  key?: string;
+  id?: string;
+  children?: TableCell[];
+  header?: boolean;
+};
+
+export type TableCell = {
+  type: 'Table.Cell';
+  key?: string;
+  id?: string;
+  children?: WidgetComponent[];
+  width?: number | string;
+  padding?: Spacing;
+  colSpan?: number;
+  rowSpan?: number;
+  align?: TableCellAlignValue;
+  vAlign?: TableCellAlignValue;
+  colSize?: TableColSize;
 };
 
 // Form Controls
@@ -494,6 +526,9 @@ type BaseTextProps = {
   truncate?: boolean;
   maxLines?: number;
 };
+
+type TableCellAlignValue = 'start' | 'center' | 'end';
+type TableColSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export type WidgetIcon =
   | 'agent'


### PR DESCRIPTION
Adds types for `Table`, `Table.Row`, and `Table.Cell` widget components which are now supported in Chatkit.