### PR TITLE
Adjust types to account for BasicRoot widgets in thread items

### DIFF
--- a/.changeset/real-coins-look.md
+++ b/.changeset/real-coins-look.md
@@ -1,0 +1,5 @@
+---
+'@openai/chatkit': minor
+---
+
+ChatKit threads now support BasicRoot widgets, types updated to reflect this

--- a/packages/chatkit/types/index.d.ts
+++ b/packages/chatkit/types/index.d.ts
@@ -192,7 +192,10 @@ export type WidgetsOption = {
    */
   onAction?: (
     action: { type: string; payload?: Record<string, unknown> },
-    widgetItem: { id: string; widget: Widgets.Card | Widgets.ListView },
+    widgetItem: {
+      id: string;
+      widget: Widgets.Card | Widgets.ListView | Widgets.BasicRoot;
+    },
   ) => Promise<void>;
 };
 


### PR DESCRIPTION
Adjust types to account for newly added support for BasicRoot as a valid WidgetRoot in a ThreadItem