### PR TITLE
Remove npm self-upgrade from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,6 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Build
         run: pnpm build
 


### PR DESCRIPTION
Remove the `npm install -g npm@latest` step from the release workflow:

* This step currently fails when the github runner's bundled npm install is missing an internal dependency (`promise-retry`), blocking the workflow.
* Updating npm globally is not required for the release; the release flow uses `pnpm` and `actions/setup-node` already configures Node/npm with the npm registry url.


