### PR TITLE
Use node version 24 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Update the release workflow to run on Node 24 instead of Node 22.

The current Node 22 runner resolves to Node 22.22.2 with npm 10.x, which is below npm’s trusted publishing requirement of npm 11.5.1+.

Verified with a diagnostic workflow (https://github.com/openai/chatkit-js/actions/runs/25407306430/job/74521116287) that GitHub Actions Node 24 resolves to:

- Node `v24.14.1`
- npm `11.11.0`
- pnpm `10.11.0`